### PR TITLE
fix division conversion checks

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -912,7 +912,7 @@ bool divFunc()
     StackBlock changeType = {};
     double newDoubleValue;
     float newFloatValue;
-    switch(theStack.top().typecode)
+    switch(tempBlock.typecode)
     {
       case 'i':
         if(theStack.top().typecode == 'i')


### PR DESCRIPTION
Estaba tronando al intentar hacer este programa

```
deff i
pushkf 35.0
pushki 2
div
popf i
prtf i
```

El error es que se esta comparando solo con el segundo elemento del stack
